### PR TITLE
handle &device=undefined param

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -232,7 +232,15 @@ class App extends Component {
     const versions = params.has('version') ?
       params.getAll('version').map(getMajorVersion) :
       ['6', '5'];
-    const device = params.get('device') || 'mobile';
+    let device = params.get('device');
+    // Default to mobile if it's not matching our known emulatedFormFactors. https://github.com/GoogleChrome/lighthouse/blob/master/types/externs.d.ts#:~:text=emulatedFormFactor
+    if (device && device !== 'mobile' && device !== 'desktop') {
+      console.log('Invalid emulatedFormFactors value:', device, '. Fallback to mobile scoring.')
+      device = 'mobile';
+    } else if (!device) {
+      // Device not expressed in the params
+      device = 'mobile';
+    }
     const scoringGuideEls = versions.map(version => {
       const key = `v${version}`;
       return <ScoringGuide app={this} name={key} values={this.state} scoring={scoringGuides[key][device]}></ScoringGuide>;

--- a/script/main.js
+++ b/script/main.js
@@ -235,7 +235,7 @@ class App extends Component {
     let device = params.get('device');
     // Default to mobile if it's not matching our known emulatedFormFactors. https://github.com/GoogleChrome/lighthouse/blob/master/types/externs.d.ts#:~:text=emulatedFormFactor
     if (device && device !== 'mobile' && device !== 'desktop') {
-      console.log('Invalid emulatedFormFactors value:', device, '. Fallback to mobile scoring.')
+      console.warning(`Invalid emulatedFormFactors value: ${device}. Fallback to mobile scoring.`);
       device = 'mobile';
     } else if (!device) {
       // Device not expressed in the params


### PR DESCRIPTION
There's obviously a bigger refactor coming when we add a dropdown for `device` but this at least unbreaks the calc for URLs like this: https://googlechrome.github.io/lighthouse/scorecalc/#first-contentful-paint=1479.242&speed-index=4627&largest-contentful-paint=3642.719&interactive=7274.491&total-blocking-time=1143.6939999999993&cumulative-layout-shift=0&first-cpu-idle=7274.491&first-meaningful-paint=1479.242&device=undefined&version=6.0.0