### PR TITLE
fix CLS desktop scorecurve

### DIFF
--- a/script/metrics.js
+++ b/script/metrics.js
@@ -25,7 +25,7 @@ export const curves = {
       LCP: {weight: 0.25, median: 2400, p10: 1200},
       TTI: {weight: 0.15, median: 4500, p10: 2468},
       TBT: {weight: 0.25, median: 350, p10: 150},
-      CLS: {weight: 0.05, median: 0, p10: 0.1},
+      CLS: {weight: 0.05, median: 0.25, p10: 0.1},
     },
   },
   v5: {


### PR DESCRIPTION
it was accidentally 0 instead of the correct 0.25. this led always having NaN scores of CLS for v6 desktop.