### PR TITLE
handle formFactor=none

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -233,9 +233,13 @@ class App extends Component {
       params.getAll('version').map(getMajorVersion) :
       ['6', '5'];
     let device = params.get('device');
-    // Default to mobile if it's not matching our known emulatedFormFactors. https://github.com/GoogleChrome/lighthouse/blob/master/types/externs.d.ts#:~:text=emulatedFormFactor
-    if (device && device !== 'mobile' && device !== 'desktop') {
-      console.warning(`Invalid emulatedFormFactors value: ${device}. Fallback to mobile scoring.`);
+    if (device && device === 'none') {
+      // Some misconfigured clients are set to emulatedFormFactor=none, which is real bad in v6.
+      console.warn(`emulatedFormFactor set to 'none'. Falling back to desktop scoring. https://github.com/GoogleChrome/lighthouse/issues/10836`);
+      device = 'desktop';
+      // Default to mobile if it's not desktop or mobile. https://github.com/GoogleChrome/lighthouse/blob/master/types/externs.d.ts#:~:text=emulatedFormFactor
+    } else if (device && device !== 'mobile' && device !== 'desktop') {
+      console.warn(`Invalid emulatedFormFactors value: ${device}. Fallback to mobile scoring.`);
       device = 'mobile';
     } else if (!device) {
       // Device not expressed in the params


### PR DESCRIPTION
from https://github.com/GoogleChrome/lighthouse/issues/10836 .. repro URL: https://googlechrome.github.io/lighthouse/scorecalc/#first-contentful-paint=1114.902&speed-index=1839&largest-contentful-paint=1898.038&interactive=1851.684&total-blocking-time=17.261999999999944&cumulative-layout-shift=0.007962289589066526&first-cpu-idle=1851.684&first-meaningful-paint=1114.902&device=none&version=6.0.0

All this flag confusion very related to https://github.com/GoogleChrome/lighthouse/issues/10910

also fix `console.warning` => `console.warn` oooooooooops.