### PR TITLE
handle v7

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ bugs:
     Learn more about scoring at <a href="https://web.dev/performance-scoring/">web.dev/performance-scoring</a>.
     <br>
     <details>
-      <summary>Scores under 5 are not supported by this UI. <abbr>Why?</abbr>
+      <summary>Scores under 5/100 are not supported by this UI. <abbr>Why?</abbr>
       </summary>
       <a href="https://www.desmos.com/calculator/dufar5rf4g">Lighthouse uses log-normal curves</a>, which have extremely long tails. If this UI supported them then 50% of the "Value" slider's width would be devoted to scores under 8, which significantly reduces the usability of the slider.
     </details>

--- a/script/main.js
+++ b/script/main.js
@@ -249,23 +249,23 @@ class App extends Component {
     this.setState({versions: e.target.value.split(',')});
   }
 
-  collapseVersions(versions) {
-    versions.forEach((version, i) => {
-      if (version < 5) {
+  normalizeVersions(versions) {
+    return versions.map(version => {
+      if (parseInt(version) < 5) {
         throw new Error(`Unsupported Lighthouse version (${version})`);
       }
-      if (version < 6) return;
-      // Back to most recent _even_ version. (As of v6, Lighthouse's even versions change scoring, but odd versions don't.)
-      if (version % 2 === 1) versions[i] = version - 1
-    });
+      // In the future we might want a more generalized `version % 2 === 1` thing, but for now, hardcode the change.
+      if (parseInt(version) === 7) return 6..toString();
+      return version.toString();
+    }).sort().reverse();
   }
 
   render() {
     const {versions, device, metricValues} = this.state;
 
-    this.collapseVersions(versions);
+    const normalizedVersions = this.normalizeVersions(versions);
 
-    const scoringGuideEls = versions.map(version => {
+    const scoringGuideEls = normalizedVersions.map(version => {
       const key = `v${version}`;
       return <ScoringGuide app={this} name={key} values={metricValues} scoring={scoringGuides[key][device]}></ScoringGuide>;
     });
@@ -278,7 +278,7 @@ class App extends Component {
           </select>
         </label>
         <label>Versions:
-          <select name="versions" value={versions.sort().reverse().join(',')} onChange={this.onVersionsChange} >
+          <select name="versions" value={normalizedVersions.join(',')} onChange={this.onVersionsChange} >
             <option value="6,5">show all</option>
             <option value="6">v6, v7</option>
             <option value="5">v5</option>

--- a/script/main.js
+++ b/script/main.js
@@ -256,7 +256,7 @@ class App extends Component {
       }
       if (version < 6) return;
       // Back to most recent _even_ version. (As of v6, Lighthouse's even versions change scoring, but odd versions don't.)
-      versions[i] = version - (version % 2)
+      if (version % 2 === 1) versions[i] = version - 1
     });
   }
 

--- a/script/main.js
+++ b/script/main.js
@@ -178,7 +178,7 @@ class ScoringGuide extends Component {
 
     let title = <h2>{name}</h2>;
     if (name === 'v6') {
-      title = <h2><a href="https://github.com/GoogleChrome/lighthouse/releases/tag/v6.0.0" target="_blank">v6</a></h2>;
+      title = <h2>latest<br/><i>v6, v7</i></h2>;
     }
 
     return <form class="wrapper">
@@ -249,8 +249,21 @@ class App extends Component {
     this.setState({versions: e.target.value.split(',')});
   }
 
+  collapseVersions(versions) {
+    versions.forEach((version, i) => {
+      if (version < 5) {
+        throw new Error(`Unsupported Lighthouse version (${version})`);
+      }
+      if (version < 6) return;
+      // Back to most recent _even_ version. (As of v6, Lighthouse's even versions change scoring, but odd versions don't.)
+      versions[i] = version - (version % 2)
+    });
+  }
+
   render() {
     const {versions, device, metricValues} = this.state;
+
+    this.collapseVersions(versions);
 
     const scoringGuideEls = versions.map(version => {
       const key = `v${version}`;
@@ -267,7 +280,7 @@ class App extends Component {
         <label>Versions:
           <select name="versions" value={versions.sort().reverse().join(',')} onChange={this.onVersionsChange} >
             <option value="6,5">show all</option>
-            <option value="6">v6</option>
+            <option value="6">v6, v7</option>
             <option value="5">v5</option>
           </select>
         </label>
@@ -278,10 +291,9 @@ class App extends Component {
 }
 
 function getInitialState() {
-  // Default to 6 and 5.
   const versions = params.has('version') ?
     params.getAll('version').map(getMajorVersion) :
-    ['6', '5'];
+    ['6'];
 
   // Default to mobile if it's not matching our known emulatedFormFactors. https://github.com/GoogleChrome/lighthouse/blob/master/types/externs.d.ts#:~:text=emulatedFormFactor
   let device = params.get('device');

--- a/script/main.js
+++ b/script/main.js
@@ -178,7 +178,7 @@ class ScoringGuide extends Component {
 
     let title = <h2>{name}</h2>;
     if (name === 'v6') {
-      title = <h2>latest<br/><i>v6, v7</i></h2>;
+      title = <h2>latest<br/><i><a href="https://github.com/GoogleChrome/lighthouse/releases/">v6, v7</a></i></h2>;
     }
 
     return <form class="wrapper">

--- a/script/metrics.js
+++ b/script/metrics.js
@@ -49,6 +49,11 @@ function makeScoringGuide(curves) {
 }
 
 export const scoringGuides = {
+  // v7 scoring is identical to v6
+  v7: {
+    mobile: makeScoringGuide(curves.v6.mobile),
+    desktop: makeScoringGuide(curves.v6.desktop),
+  },
   v6: {
     mobile: makeScoringGuide(curves.v6.mobile),
     desktop: makeScoringGuide(curves.v6.desktop),


### PR DESCRIPTION
* version=7 in the URL now works
   - example: `#FCP=671&SI=671&LCP=762&TTI=671&TBT=0&CLS=0&FCI=671&FMP=671&device=mobile&version=7.0.0`
* default UI now excludes v5 scores
* UX-wise, to help communicate that v6 and v7 scoring is identical, i've grouped them into a single "item"