### PR TITLE
initalize with mobile medians

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -315,7 +315,7 @@ function getInitialState() {
   // Populate metricValues from query string.
   for (const [id, metric] of Object.entries(metrics)) {
     const value = params.get(id) || params.get(metric.auditId);
-    if (value === null) continue;
+    if (!value) continue;
     metricValues[id] = Number(value);
   }
 

--- a/script/main.js
+++ b/script/main.js
@@ -305,17 +305,17 @@ function getInitialState() {
     device = 'mobile';
   }
 
-  // Set defaults as median.
   const metricValues = {};
-  const metricScorings = {...scoringGuides.v6.desktop, ...scoringGuides.v5.desktop};
+  // If no metric values come in w/ params, initalize with mobile medians (score of 50)
+  const metricScorings = {...scoringGuides.v5.mobile, ...scoringGuides.v6.mobile}; // v5 is neccessary for FCI
   for (const id in metricScorings) {
     metricValues[id] = metricScorings[id].median;
   }
 
-  // Load from query string.
+  // Populate metricValues from query string.
   for (const [id, metric] of Object.entries(metrics)) {
     const value = params.get(id) || params.get(metric.auditId);
-    if (value === undefined) continue;
+    if (value === null) continue;
     metricValues[id] = Number(value);
   }
 


### PR DESCRIPTION
`params.get('key_not_in_params')` returns a null, not undefined, so this wasn't working as we expected it to.

fixed and added a few more comments.

intended behavior: if you load the scorecalc with nothing in the URL, you'll see a 50 perf score and each metric has a metric score of 50. nice for playing around.

