### PR TITLE
disable ES feature transforms

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,10 +17,7 @@ export default {
     buble({
       jsx: 'h',
       objectAssign: 'Object.assign',
-      transforms: {
-        asyncAwait: false,
-        forOf: false,
-      },
+      target: { chrome: 71, safari: 11.1, firefox: 64 }, // roughly disable ES feature transpilation
 		}),
     commonjs(),
     visualizer(), // build and view stats.html


### PR DESCRIPTION
while debugging i got very confused.. all because some for..of loops got their `const`s replaced with `var` which were then hoisted out of the blocks. terrible terrible stuff.

